### PR TITLE
Add bluetooth and wifi toggling via TLP

### DIFF
--- a/README.org
+++ b/README.org
@@ -67,6 +67,8 @@ keybinding if ~desktop-environment-mode~ is enabled:
 | desktop-environment-screenshot-part             | ~S-<print>~                 |
 | desktop-environment-screenshot                  | ~<print>~                   |
 | desktop-environment-lock-screen                 | ~s-l~                       |
+| desktop-environment-toggle-wifi                 | ~<XF86WLAN>~                |
+| desktop-environment-toggle-bluetooth            | ~<XF86Bluetooth>~           |
 
 ** Dependencies
 To use every commands desktop-environment provides, the following packages must
@@ -76,6 +78,7 @@ be available on your system:
     - Screenshot: [[https://tracker.debian.org/pkg/scrot][scrot]]
     - Screenlock: [[https://tools.suckless.org/slock/][slock]]
     - Keyboard backlight: [[https://upower.freedesktop.org/][upower]]
+    - Wifi and bluetooth: [[https://linrunner.de/en/tlp/tlp.html][TLP]]
 
 ** License
 

--- a/desktop-environment.el
+++ b/desktop-environment.el
@@ -164,6 +164,18 @@ portion of the screen."
   :type 'string)
 
 
+;;; Customization - wifi
+
+(defcustom desktop-environment-wifi-command "wifi toggle"
+  "Shell command toggling wifi."
+  :type 'string)
+
+;;; Customization - bluetooth
+
+(defcustom desktop-environment-bluetooth-command "bluetooth toggle"
+  "Shell command toggling bluetooth."
+  :type 'string)
+
 ;;; Helper functions - brightness
 
 (defun desktop-environment-brightness-get ()
@@ -349,6 +361,24 @@ the screen."
     (async-shell-command desktop-environment-screenlock-command)))
 
 
+;;; Commands - wifi
+
+;;;###autoload
+(defun desktop-environment-toggle-wifi ()
+  "Toggle wifi adapter on and off."
+  (interactive)
+  (let ((async-shell-command-buffer 'new-buffer))
+    (async-shell-command desktop-environment-wifi-command)))
+
+;;; Commands - bluetooth
+
+;;;###autoload
+(defun desktop-environment-toggle-bluetooth ()
+  "Toggle bluetooth on and off."
+  (interactive)
+  (let ((async-shell-command-buffer 'new-buffer))
+    (async-shell-command desktop-environment-bluetooth-command)))
+  
 ;;; Minor mode
 
 (defvar desktop-environment-mode-map
@@ -369,7 +399,11 @@ the screen."
            (,(kbd "S-<print>") . ,(function desktop-environment-screenshot-part))
            (,(kbd "<print>") . ,(function desktop-environment-screenshot))
            ;; Screen locking
-           (,(kbd "s-l") . ,(function desktop-environment-lock-screen))))
+           (,(kbd "s-l") . ,(function desktop-environment-lock-screen))
+           ;; Wifi controls
+           (,(kbd "<XF86WLAN>") . ,(function desktop-enviroment-toggle-wifi))
+           ;; Bluetooth controls
+           (,(kbd "<XF86Bluetooth>") . ,(function desktop-enviroment-toggle-bluetooth))))
         (map (make-sparse-keymap)))
     (dolist (keybinding desktop-environment--keybindings)
       (define-key map (car keybinding) (cdr keybinding)))


### PR DESCRIPTION
I  made a simple modification that enables the user to toggle wifi and bluetooth with XF86 keys or with a function.

But this means that my version is dependent on TLP. But since TLP should be installed on every laptop I thought this wouldn't be a big issue.