### PR TITLE
Add keyboard layout switching

### DIFF
--- a/README.org
+++ b/README.org
@@ -52,23 +52,33 @@ ones above:
 The following table summarizes the available commands and their
 keybinding if ~desktop-environment-mode~ is enabled:
 
-| *Command*                                       | *Key binding*               |
-|-------------------------------------------------+-----------------------------|
-| desktop-environment-brightness-increment        | ~<XF86MonBrightnessUp>~     |
-| desktop-environment-brightness-decrement        | ~<XF86MonBrightnessDown>~   |
-| desktop-environment-brightness-increment-slowly | ~S-<XF86MonBrightnessUp>~   |
-| desktop-environment-brightness-decrement-slowly | ~S-<XF86MonBrightnessDown>~ |
-| desktop-environment-volume-increment            | ~<XF86AudioRaiseVolume>~    |
-| desktop-environment-volume-decrement            | ~<XF86AudioLowerVolume>~    |
-| desktop-environment-volume-increment-slowly     | ~S-<XF86AudioRaiseVolume>~  |
-| desktop-environment-volume-decrement-slowly     | ~S-<XF86AudioLowerVolume>~  |
-| desktop-environment-toggle-mute                 | ~<XF86AudioMute>~           |
-| desktop-environment-toggle-microphone-mute      | ~<XF86AudioMicMute>~        |
-| desktop-environment-screenshot-part             | ~S-<print>~                 |
-| desktop-environment-screenshot                  | ~<print>~                   |
-| desktop-environment-lock-screen                 | ~s-l~                       |
-| desktop-environment-toggle-wifi                 | ~<XF86WLAN>~                |
-| desktop-environment-toggle-bluetooth            | ~<XF86Bluetooth>~           |
+| *Command*                                          | *Key binding*               |
+|----------------------------------------------------+-----------------------------|
+| desktop-environment-brightness-increment           | ~<XF86MonBrightnessUp>~     |
+| desktop-environment-brightness-decrement           | ~<XF86MonBrightnessDown>~   |
+| desktop-environment-brightness-increment-slowly    | ~S-<XF86MonBrightnessUp>~   |
+| desktop-environment-brightness-decrement-slowly    | ~S-<XF86MonBrightnessDown>~ |
+| desktop-environment-volume-increment               | ~<XF86AudioRaiseVolume>~    |
+| desktop-environment-volume-decrement               | ~<XF86AudioLowerVolume>~    |
+| desktop-environment-volume-increment-slowly        | ~S-<XF86AudioRaiseVolume>~  |
+| desktop-environment-volume-decrement-slowly        | ~S-<XF86AudioLowerVolume>~  |
+| desktop-environment-toggle-mute                    | ~<XF86AudioMute>~           |
+| desktop-environment-toggle-microphone-mute         | ~<XF86AudioMicMute>~        |
+| desktop-environment-screenshot-part                | ~S-<print>~                 |
+| desktop-environment-screenshot                     | ~<print>~                   |
+| desktop-environment-lock-screen                    | ~s-l~                       |
+| desktop-environment-toggle-wifi                    | ~<XF86WLAN>~                |
+| desktop-environment-toggle-bluetooth               | ~<XF86Bluetooth>~           |
+| desktop-environment-keyboard-layout-cycle-forward  | ~s-SPC~                     |
+| desktop-environment-keyboard-layout-cycle-backward | ~s-S-SPC~                   |
+
+*** Keyboard layouts
+
+Keyboard layouts are stored in a variable called ~desktop-environment-keyboard-layouts~ as parameters for the ~setxkbmap~ shell command. (To be accurate ~setxkbmap -layout ~) To load keyboard layout automatically on startup add following to your configuration file:
+
+#+begin_src emacs-lisp
+(add-hook 'after-init-hook 'desktop-environment-keyboard-layout-cycle-forward)
+#+end_src
 
 ** Dependencies
 To use every commands desktop-environment provides, the following packages must


### PR DESCRIPTION
I have finally finished keyboard switching. It should work without any additional dependencies since it is using only X11 keymaps already available in every EXWM and most other WMs and DEs.

I've also added some little explanation how to use this feature to it's full potential. (loading keymap on emacs startup)

Layouts are stored as simple list that is passed as an argument for `setxkbmap -layout ` and can be further modified with `-variant xxx` or `-model xxx` etc.