### PR TITLE
Add an additional screensaver binding

### DIFF
--- a/README.org
+++ b/README.org
@@ -66,7 +66,7 @@ keybinding if ~desktop-environment-mode~ is enabled:
 | desktop-environment-toggle-microphone-mute      | ~<XF86AudioMicMute>~        |
 | desktop-environment-screenshot-part             | ~S-<print>~                 |
 | desktop-environment-screenshot                  | ~<print>~                   |
-| desktop-environment-lock-screen                 | ~s-l~                       |
+| desktop-environment-lock-screen                 | ~s-l~ or ~<XF86ScreenSaver>~  |
 | desktop-environment-toggle-wifi                 | ~<XF86WLAN>~                |
 | desktop-environment-toggle-bluetooth            | ~<XF86Bluetooth>~           |
 | desktop-environment-toggle-music                | ~<XF86AudioPlay>~           |

--- a/desktop-environment.el
+++ b/desktop-environment.el
@@ -445,6 +445,7 @@ the screen."
            (,(kbd "<print>") . ,(function desktop-environment-screenshot))
            ;; Screen locking
            (,(kbd "s-l") . ,(function desktop-environment-lock-screen))
+           (,(kbd "<XF86ScreenSaver>") . ,(function desktop-environment-lock-screen))
            ;; Wifi controls
            (,(kbd "<XF86WLAN>") . ,(function desktop-environment-toggle-wifi))
            ;; Bluetooth controls


### PR DESCRIPTION
On my thinkpad x60s I have `<X86ScreenSaver>` under Fn `<F2>`. The same key may be available to others too. I don't believe having two keybindings like this would cause a conflict but feel free to correct if necessary. This could resolve issue #1 or at least allow those that have this keybinding to disable `s-l`. I've updated the README too but I'm not sure why but alignment for the table elements differed for me when I first opened the README. Pressing `<TAB>` fixed the aligment but then created more diffs so I left it as is to avoid these extra diffs. In any case, it appears to be rendered correctly here on github.

Thanks for your time and this package.