### PR TITLE
Change `start-process-shell-command` to `shell-command`

### DIFF
--- a/desktop-environment.el
+++ b/desktop-environment.el
@@ -448,7 +448,6 @@ the command `desktop-environment-screenshot-partial-command'."
 (defun desktop-environment-lock-screen ()
   "Lock the screen, preventing anyone without a password from using the system."
   (interactive)
-  ;; Run command asynchronously so that Emacs does not wait in the background.
   (shell-command desktop-environment-screenlock-command))
 
 

--- a/desktop-environment.el
+++ b/desktop-environment.el
@@ -410,7 +410,7 @@ the command `desktop-environment-screenshot-command'."
                              " "
                              (format desktop-environment-screenshot-delay-argument delay))
                    desktop-environment-screenshot-command)))
-    (start-process-shell-command "desktop-environment-screenshot" nil command)))
+    (shell-command command)))
 
 ;;;###autoload
 (defun desktop-environment-screenshot-part (&optional delay)
@@ -439,7 +439,7 @@ the command `desktop-environment-screenshot-partial-command'."
                              (format desktop-environment-screenshot-delay-argument delay))
                    desktop-environment-screenshot-partial-command)))
     (message "Please select the part of your screen to shoot.")
-    (start-process-shell-command "desktop-environment-screenshot" nil command)))
+    (shell-command command)))
 
 
 ;;; Commands - screen locking
@@ -449,7 +449,7 @@ the command `desktop-environment-screenshot-partial-command'."
   "Lock the screen, preventing anyone without a password from using the system."
   (interactive)
   ;; Run command asynchronously so that Emacs does not wait in the background.
-  (start-process-shell-command "lock" nil desktop-environment-screenlock-command))
+  (shell-command desktop-environment-screenlock-command))
 
 
 ;;; Commands - wifi


### PR DESCRIPTION
As discussed in #23, this PR changes all instances `start-process-shell-command` to `shell-command`.

In doing so it allows the `i3lock` screen lock command to work as expected. Screenshot commands also seem to work as expected.

However, it also causes some changes that merit some discussion:

1. After a commend exits, the message `(shell command succeeded without any output)` appears in the echo area. Is this acceptable? I couldn't find any way to get rid of it.
2. Is it bad that the screen lock command runs synchronously? It was
previously preceded by a comment that read: 
	```emacs-lisp
	;; Run command asynchronously so that Emacs does not wait in the background. 
	``` 
	I don't know whether this will cause any issues. It might be possible to use `async-shell-command` instead, though that has the unwanted side effect of bringing up an output buffer, even with no output.

Further, these points might need clarification:

1. Are there any tests to run?
2. Will this cause any issues with any other screen lock commands? Can we check this somehow?