### PR TITLE
Trim the output of shell commands (#1)

### DIFF
--- a/desktop-environment.el
+++ b/desktop-environment.el
@@ -242,7 +242,7 @@ replacing the placeholder %d with the prefix argument."
 (defun desktop-environment--shell-command-to-string (command)
   "Execute shell command COMMAND locally and return its output as a string."
    (let ((default-directory temporary-file-directory))
-      (shell-command-to-string command)))
+      (string-trim (shell-command-to-string command))))
 
 ;;; Helper functions - brightness
 


### PR DESCRIPTION
Certain command outputs contain trailing newlines, which will make the output in the echo area two lines when it could be one.